### PR TITLE
Use octicon for plus sign

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -131,13 +131,16 @@ function onClickHanlder(ev) {
 	});
 }
 
-function addButton(n,u) {
+function addButton(doc,n,u) {
 	let p = n.parentNode;
 	n = n.cloneNode(!0);
 	
 	n.id = addon.tag;
 	n.title = 'Install Extension';
-	n.innerHTML = '<span class="octicon octicon-plus"></span>Add to ' + Services.appinfo.name;
+	n.textContent = 'Add to ' + Services.appinfo.name;
+
+	let s = n.insertBefore(doc.createElement('span'), n.firstChild);
+	s.className = 'octicon octicon-plus';
 	p.appendChild(n);
 	
 	n.addEventListener('click', onClickHanlder, false);
@@ -159,7 +162,7 @@ function onPageLoad(doc) {
 		
 		if(n && n.textContent.trim() === 'Download ZIP') {
 			
-			addButton(n);
+			addButton(doc,n);
 		}
 	}
 	
@@ -178,7 +181,7 @@ function onPageLoad(doc) {
 					'archive', b.join(':') + '.zip'
 				].join('/');
 			
-			addButton(n,u);
+			addButton(doc,n,u);
 		}
 	}
 }


### PR DESCRIPTION
Preview:

![githubextins-before](https://f.cloud.github.com/assets/42596/2160978/e0304aba-94c0-11e3-8e39-e63cd227d864.png) ![githubextins-after](https://f.cloud.github.com/assets/42596/2160984/ed6d8936-94c0-11e3-83a4-6fa95dff1a09.png)

Doesn't look much different but at least it matches with other buttons.

If you prefer other icon &mdash; [beer](https://f.cloud.github.com/assets/42596/2161186/22ef4e12-94c3-11e3-9ad1-644990311c83.png), for example &mdash; see https://github.com/styleguide/css/7.0
