### PR TITLE
Use Firefox extension installed dialog

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -124,6 +124,8 @@ function onClickHanlder(ev) {
 							removeOnDismissal: true
 						};
 
+						if(addon.icon) options.popupIconURL = addon.icon;
+
 						let gBrowser = getBrowser(),
 							gDoc = gBrowser.ownerDocument,
 							gNavigatorBundle = gDoc.getElementById("bundle_browser");

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -15,7 +15,6 @@ Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/FileUtils.jsm");
 Cu.import("resource://gre/modules/AddonManager.jsm");
-Cu.import('resource://gre/modules/PopupNotifications.jsm');
 
 function LOG(m) (m = addon.name + ' Message @ '
 	+ (new Date()).toISOString() + "\n> " + m,
@@ -129,6 +128,7 @@ function onClickHanlder(ev) {
 							gDoc = gBrowser.ownerDocument,
 							gNavigatorBundle = gDoc.getElementById("bundle_browser");
 
+						Cu.import('resource://gre/modules/PopupNotifications.jsm');
 						let notify = new PopupNotifications(
 							gBrowser,
 							gDoc.getElementById("notification-popup"),


### PR DESCRIPTION
Fixes https://github.com/diegocr/GitHubExtIns/issues/7

![Firefox extension installed dialog](https://f.cloud.github.com/assets/55841/2238662/8c7f6018-9bfa-11e3-9804-658d6ef94753.png)

This PR removes the pref `'nme'`.

Please review my code, as I couldn't test an addon failure.

Todo:
- [x] Use addon icon in dialog.
- [ ] Test for Android.
